### PR TITLE
Fixes sign problem in `roty`

### DIFF
--- a/src/bloch/bloch.c
+++ b/src/bloch/bloch.c
@@ -326,7 +326,7 @@ for (tcount = 0; tcount < ntime; tcount++)
 	rotz = -(*xgrad++ * gammadx + *ygrad++ * gammady + *zgrad++ * gammadz +
 								df*TWOPI ) * *tsteps;
 	rotx = (- *b1real++ * GAMMA * *tsteps);
-	roty = (+ *b1imag++ * GAMMA * *tsteps++);
+	roty = (- *b1imag++ * GAMMA * *tsteps++);
 	calcrotmat(rotx, roty, rotz, rotmat);
 
 	if (mode == 1)


### PR DESCRIPTION
Thanks for this updated Python version of Brian Hargreaves's code! I am using it to teach Bloch simulations and I noticed a bug.

The sign of `roty` is incorrect, as `calcrotmat` generates right-handed rotations. This bug generates incorrect simulations when using slice-selective RF pulses which include frequency offsets, as the slice position moves in the wrong direction.

There are other versions of this code with the same fix: [https://github.com/ismrmrd/ismrmrd-paper/blob/master/code/extern/irt/mri-rf/sun-bloch/blochCim.c](https://github.com/ismrmrd/ismrmrd-paper/blob/master/code/extern/irt/mri-rf/sun-bloch/blochCim.c)

Cheers!